### PR TITLE
Fix importing lodash.mapvalues on case sensitive filesystems

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import keys from 'object-keys';
 import omit from 'lodash.omit';
 import pick from 'lodash.pick';
-import mapValues from 'lodash.mapValues';
+import mapValues from 'lodash.mapvalues';
 
 
 const mkFirstFunc = (method) => (str) => str.slice(0, 1)[method]() + str.slice(1);


### PR DESCRIPTION
`mapValues` works on case insensitive filesystems, but doesn't work on case sensitive (e.g. Linux)
